### PR TITLE
Allow variables as parameters

### DIFF
--- a/lib/jekyll-gist/gist_tag.rb
+++ b/lib/jekyll-gist/gist_tag.rb
@@ -5,10 +5,10 @@ module Jekyll
       def render(context)
         if tag_contents = determine_arguments(@markup.strip)
           gist_id, filename = tag_contents[0], tag_contents[1]
-          if context.key?(gist_id)
+          if context[gist_id]
             gist_id = context[gist_id]
           end
-          if context.key?(filename)
+          if context[filename]
             filename = context[filename]
           end
           gist_script_tag(gist_id, filename)

--- a/lib/jekyll-gist/gist_tag.rb
+++ b/lib/jekyll-gist/gist_tag.rb
@@ -5,6 +5,12 @@ module Jekyll
       def render(context)
         if tag_contents = determine_arguments(@markup.strip)
           gist_id, filename = tag_contents[0], tag_contents[1]
+          if context.key?(gist_id)
+            gist_id = context[gist_id]
+          end
+          if context.key?(filename)
+            filename = context[filename]
+          end
           gist_script_tag(gist_id, filename)
         else
           raise ArgumentError.new <<-eos

--- a/spec/gist_tag_spec.rb
+++ b/spec/gist_tag_spec.rb
@@ -43,6 +43,35 @@ describe(Jekyll::Gist::GistTag) do
         expect(output).to match(/<script src="https:\/\/gist.github.com\/#{gist}.js\?file=#{filename}">\s<\/script>/)
       end
     end
+
+    context "with variable gist id" do
+      let(:gist)     { "page.gist_id" }
+      let(:output) do
+        doc.data['gist_id'] = "1342013"
+        doc.content = content
+        doc.output  = Jekyll::Renderer.new(doc.site, doc).run
+      end
+
+      it "produces the correct script tag" do
+        expect(output).to match(/<script src="https:\/\/gist.github.com\/#{doc.data['gist_id']}.js">\s<\/script>/)
+      end
+    end
+
+    context "with variable gist id and filename" do
+      let(:gist)     { "page.gist_id" }
+      let(:filename) { "page.gist_filename" }
+      let(:content)  { "{% gist #{gist} #{filename} %}" }
+      let(:output) do
+        doc.data['gist_id'] = "1342013"
+        doc.data['gist_filename'] = "atom.xml"
+        doc.content = content
+        doc.output  = Jekyll::Renderer.new(doc.site, doc).run
+      end
+
+      it "produces the correct script tag" do
+        expect(output).to match(/<script src="https:\/\/gist.github.com\/#{doc.data['gist_id']}.js\?file=#{doc.data['gist_filename']}">\s<\/script>/)
+      end
+    end
   end
 
 


### PR DESCRIPTION
This will first check to see if the passed parameters exist in `context` and, if so, substitute those values in place of the parameter.

This allows specifying things like the Gist ID in a pages front matter.

```liquid
---
gist: 1342013
---

{% gist page.gist %}
```

Added test, but no docs.

Fixes #2 