### PR TITLE
Added an noscript fallback for browsers without javascript enabled.

### DIFF
--- a/jekyll-gist.gemspec
+++ b/jekyll-gist.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "webmock"
   spec.add_development_dependency "jekyll", "~> 2.0"
 end

--- a/lib/jekyll-gist/gist_tag.rb
+++ b/lib/jekyll-gist/gist_tag.rb
@@ -59,13 +59,10 @@ module Jekyll
       end
 
       def fetch_raw_code(gist_id, filename = nil)
-        if filename.empty?
-          uri = "https://gist.githubusercontent.com/#{gist_id}/raw"
-        else
-          uri = "https://gist.githubusercontent.com/#{gist_id}/raw/#{filename}"
-        end
         begin
-          open(uri).read.chomp
+          url = "https://gist.githubusercontent.com/#{gist_id}/raw"
+          url = "#{url}/#{filename}" unless filename.empty?
+          open(url).read.chomp
         rescue SocketError
           nil
         rescue OpenURI::HTTPError

--- a/lib/jekyll-gist/gist_tag.rb
+++ b/lib/jekyll-gist/gist_tag.rb
@@ -52,7 +52,9 @@ module Jekyll
         if !code.nil?
           "<noscript><pre>#{CGI.escapeHTML(code)}</pre></noscript>"
         else
-          Jekyll.logger.warn "Warning:", "The <noscript> tag for your gist #{gist_id} could not be generated. This will affect users who do not have JavaScript available or enabled in their browsers."
+          Jekyll.logger.warn "Warning:", "The <noscript> tag for your gist #{gist_id} could not"
+          Jekyll.logger.warn "", "be generated. This will affect users who do not have"
+          Jekyll.logger.warn "", "JavaScript available or enabled in their browsers."
         end
       end
 

--- a/lib/jekyll-gist/gist_tag.rb
+++ b/lib/jekyll-gist/gist_tag.rb
@@ -1,3 +1,6 @@
+require 'cgi'
+require 'open-uri'
+
 module Jekyll
   module Gist
     class GistTag < Liquid::Tag
@@ -11,7 +14,9 @@ module Jekyll
           if context.has_key?(filename)
             filename = context[filename]
           end
-          gist_script_tag(gist_id, filename)
+          noscript_tag = gist_noscript_tag(gist_id, filename)
+          script_tag = gist_script_tag(gist_id, filename)
+          "#{noscript_tag}#{script_tag}"
         else
           raise ArgumentError.new <<-eos
   Syntax error in tag 'gist' while parsing the following markup:
@@ -40,6 +45,16 @@ module Jekyll
         else
           "<script src=\"https://gist.github.com/#{gist_id}.js?file=#{filename}\"> </script>"
         end
+      end
+
+      def gist_noscript_tag(gist_id, filename = nil)
+        if filename.empty?
+          uri = "https://gist.githubusercontent.com/#{gist_id}/raw"
+        else
+          uri = "https://gist.githubusercontent.com/#{gist_id}/raw/#{filename}"
+        end
+        code = open(uri).read.chomp
+        "<noscript><pre>#{CGI.escapeHTML(code)}</pre></noscript>"
       end
 
     end

--- a/lib/jekyll-gist/gist_tag.rb
+++ b/lib/jekyll-gist/gist_tag.rb
@@ -51,6 +51,8 @@ module Jekyll
         code = fetch_raw_code(gist_id, filename)
         if !code.nil?
           "<noscript><pre>#{CGI.escapeHTML(code)}</pre></noscript>"
+        else
+          Jekyll.logger.warn "Warning:", "The <noscript> tag for your gist #{gist_id} could not be generated. This will affect users who do not have JavaScript available or enabled in their browsers."
         end
       end
 

--- a/lib/jekyll-gist/gist_tag.rb
+++ b/lib/jekyll-gist/gist_tag.rb
@@ -48,15 +48,24 @@ module Jekyll
       end
 
       def gist_noscript_tag(gist_id, filename = nil)
+        code = fetch_raw_code(gist_id, filename)
+        if !code.nil?
+          "<noscript><pre>#{CGI.escapeHTML(code)}</pre></noscript>"
+        end
+      end
+
+      def fetch_raw_code(gist_id, filename = nil)
         if filename.empty?
           uri = "https://gist.githubusercontent.com/#{gist_id}/raw"
         else
           uri = "https://gist.githubusercontent.com/#{gist_id}/raw/#{filename}"
         end
-        code = open(uri).read.chomp
-        "<noscript><pre>#{CGI.escapeHTML(code)}</pre></noscript>"
+        begin
+          open(uri).read.chomp
+        rescue OpenURI::HTTPError => e
+          nil
+        end
       end
-
     end
   end
 end

--- a/lib/jekyll-gist/gist_tag.rb
+++ b/lib/jekyll-gist/gist_tag.rb
@@ -40,11 +40,9 @@ module Jekyll
       end
 
       def gist_script_tag(gist_id, filename = nil)
-        if filename.empty?
-          "<script src=\"https://gist.github.com/#{gist_id}.js\"> </script>"
-        else
-          "<script src=\"https://gist.github.com/#{gist_id}.js?file=#{filename}\"> </script>"
-        end
+        url = "https://gist.github.com/#{gist_id}.js"
+        url = "#{url}?file=#{filename}" unless filename.empty?
+        "<script src=\"#{url}\"> </script>"
       end
 
       def gist_noscript_tag(gist_id, filename = nil)

--- a/lib/jekyll-gist/gist_tag.rb
+++ b/lib/jekyll-gist/gist_tag.rb
@@ -66,6 +66,8 @@ module Jekyll
           open(uri).read.chomp
         rescue SocketError
           nil
+        rescue OpenURI::HTTPError
+          nil
         end
       end
     end

--- a/lib/jekyll-gist/gist_tag.rb
+++ b/lib/jekyll-gist/gist_tag.rb
@@ -62,7 +62,7 @@ module Jekyll
         end
         begin
           open(uri).read.chomp
-        rescue OpenURI::HTTPError => e
+        rescue SocketError
           nil
         end
       end

--- a/spec/gist_tag_spec.rb
+++ b/spec/gist_tag_spec.rb
@@ -94,13 +94,30 @@ describe(Jekyll::Gist::GistTag) do
       end
 
       it "produces the correct script tag" do
-        expect(output).to match(/<script src="https:\/\/gist.github.com\/#{doc.data['gist_id']}.js\?file=#{doc.data['gist_filename']}">\s<\/script>\n\n/)
+        expect(output).to match(/<script src="https:\/\/gist.github.com\/#{doc.data['gist_id']}.js\?file=#{doc.data['gist_filename']}">\s<\/script>/)
       end
 
       it "produces the correct noscript tag" do 
         expect(output).to match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
       end
     end
+
+    context "with valid gist id and invalid filename" do 
+      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist_id}/raw/#{gist_filename}").to_return(status: 404) }
+      let(:gist_id)     { "mattr-/24081a1d93d2898ecf0f" }
+      let(:gist_filename) { "myfile.ext" }
+      let(:content)  { "{% gist #{gist_id} #{gist_filename} %}" }
+
+      it "produces the correct script tag" do
+        expect(output).to match(/<script src="https:\/\/gist.github.com\/#{gist_id}.js\?file=#{gist_filename}">\s<\/script>/)
+      end
+
+      it "doesn't produces the noscript tag" do 
+        expect(output).to_not match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
+      end
+
+    end
+
   end
 
 

--- a/spec/gist_tag_spec.rb
+++ b/spec/gist_tag_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe(Jekyll::Gist::GistTag) do
+  let(:http_output) { "<test>true</test>" }
   let(:doc) { doc_with_content(content) }
   let(:content)  { "{% gist #{gist} %}" }
   let(:output) do
@@ -11,30 +12,43 @@ describe(Jekyll::Gist::GistTag) do
 
   context "valid gist" do
     context "with user prefix" do
+      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist}/raw").to_return(body: http_output) }
       let(:gist) { "mattr-/24081a1d93d2898ecf0f" }
 
       it "produces the correct script tag" do
         expect(output).to match(/<script src="https:\/\/gist.github.com\/#{gist}.js">\s<\/script>/)
       end
+      it "produces the correct noscript tag" do 
+        expect(output).to match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
+      end
     end
 
     context "without user prefix" do
+      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist}/raw").to_return(body: http_output) }
       let(:gist) { "28949e1d5ee2273f9fd3" }
 
       it "produces the correct script tag" do
         expect(output).to match(/<script src="https:\/\/gist.github.com\/#{gist}.js">\s<\/script>/)
       end
+      it "produces the correct noscript tag" do 
+        expect(output).to match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
+      end
     end
 
     context "classic Gist id style" do
+      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist}/raw").to_return(body: http_output) }
       let(:gist) { "1234321" }
 
       it "produces the correct script tag" do
         expect(output).to match(/<script src="https:\/\/gist.github.com\/#{gist}.js">\s<\/script>/)
       end
+      it "produces the correct noscript tag" do 
+        expect(output).to match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
+      end
     end
 
     context "with file specified" do
+      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist}/raw/#{filename}").to_return(body: http_output) }
       let(:gist)     { "mattr-/24081a1d93d2898ecf0f" }
       let(:filename) { "myfile.ext" }
       let(:content)  { "{% gist #{gist} #{filename} %}" }
@@ -42,12 +56,17 @@ describe(Jekyll::Gist::GistTag) do
       it "produces the correct script tag" do
         expect(output).to match(/<script src="https:\/\/gist.github.com\/#{gist}.js\?file=#{filename}">\s<\/script>/)
       end
+      it "produces the correct noscript tag" do 
+        expect(output).to match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
+      end
     end
 
     context "with variable gist id" do
+      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist_id}/raw").to_return(body: http_output) }
+      let(:gist_id)  { "1342013" }
       let(:gist)     { "page.gist_id" }
       let(:output) do
-        doc.data['gist_id'] = "1342013"
+        doc.data['gist_id'] = gist_id
         doc.content = content
         doc.output  = Jekyll::Renderer.new(doc.site, doc).run
       end
@@ -55,12 +74,18 @@ describe(Jekyll::Gist::GistTag) do
       it "produces the correct script tag" do
         expect(output).to match(/<script src="https:\/\/gist.github.com\/#{doc.data['gist_id']}.js">\s<\/script>/)
       end
+      it "produces the correct noscript tag" do 
+        expect(output).to match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
+      end
     end
 
     context "with variable gist id and filename" do
-      let(:gist)     { "page.gist_id" }
-      let(:filename) { "page.gist_filename" }
-      let(:content)  { "{% gist #{gist} #{filename} %}" }
+      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist_id}/raw/#{gist_filename}").to_return(body: http_output) }
+      let(:gist_id)       { "1342013" }
+      let(:gist_filename) { "atom.xml" }
+      let(:gist)          { "page.gist_id" }
+      let(:filename)      { "page.gist_filename" }
+      let(:content)       { "{% gist #{gist} #{filename} %}" }
       let(:output) do
         doc.data['gist_id'] = "1342013"
         doc.data['gist_filename'] = "atom.xml"
@@ -69,7 +94,11 @@ describe(Jekyll::Gist::GistTag) do
       end
 
       it "produces the correct script tag" do
-        expect(output).to match(/<script src="https:\/\/gist.github.com\/#{doc.data['gist_id']}.js\?file=#{doc.data['gist_filename']}">\s<\/script>/)
+        expect(output).to match(/<script src="https:\/\/gist.github.com\/#{doc.data['gist_id']}.js\?file=#{doc.data['gist_filename']}">\s<\/script>\n\n/)
+      end
+
+      it "produces the correct noscript tag" do 
+        expect(output).to match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
       end
     end
   end

--- a/spec/gist_tag_spec.rb
+++ b/spec/gist_tag_spec.rb
@@ -112,7 +112,7 @@ describe(Jekyll::Gist::GistTag) do
         expect(output).to match(/<script src="https:\/\/gist.github.com\/#{gist_id}.js\?file=#{gist_filename}">\s<\/script>/)
       end
 
-      it "doesn't produces the noscript tag" do 
+      it "does not produce the noscript tag" do 
         expect(output).to_not match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 TEST_DIR = File.dirname(__FILE__)
 TMP_DIR  = File.expand_path("../tmp", TEST_DIR)
 
+require 'webmock/rspec'
+require 'cgi'
 require 'jekyll'
 require File.expand_path("../lib/jekyll-gist.rb", TEST_DIR)
 


### PR DESCRIPTION
This would be better for RSS readers and users with tinfoil hats and disabled javascript. It fetches the code via HTTP, escapes it and wraps into an noscript-Tag. To make the specs work again I had to add webmock to the development dependencies, so I had to update all specs and added new it-blocks to each context and an before-Block to stub the request. :muscle: 

If there are any questions, don't hesitate to answer. I hope dearly that you will accept the PR, so all jekyll-gist users can profit from that change soon. :smile: 

Have a great day :sun_with_face: