### PR TITLE
TimeoutError is thrown by net/http on ruby 1.9.3

### DIFF
--- a/lib/jekyll-gist/gist_tag.rb
+++ b/lib/jekyll-gist/gist_tag.rb
@@ -71,7 +71,7 @@ module Jekyll
             response = http.request(request)
             response.body
           end
-        rescue SocketError, Net::HTTPError, Net::OpenTimeout, Net::ReadTimeout
+        rescue SocketError, Net::HTTPError, Net::OpenTimeout, Net::ReadTimeout, TimeoutError
           nil
         end
       end


### PR DESCRIPTION
As a followup to #14 I just added that TimeoutError to the rescue clause. It is raised by net/http on 1.9.3 when one of the timeouts is hit. :smile: 

/cc @parkr 