### PR TITLE
Fix encoding error for gist_tag

### DIFF
--- a/lib/jekyll-gist/gist_tag.rb
+++ b/lib/jekyll-gist/gist_tag.rb
@@ -9,6 +9,7 @@ module Jekyll
     class GistTag < Liquid::Tag
 
       def render(context)
+        @encoding = context.registers[:site].config['encoding']
         if tag_contents = determine_arguments(@markup.strip)
           gist_id, filename = tag_contents[0], tag_contents[1]
           if context.has_key?(gist_id)
@@ -69,7 +70,7 @@ module Jekyll
             read_timeout: 3, open_timeout: 3) do |http|
             request = Net::HTTP::Get.new uri.to_s
             response = http.request(request)
-            response.body
+            response.body.force_encoding(@encoding)
           end
         rescue SocketError, Net::HTTPError, Net::OpenTimeout, Net::ReadTimeout, TimeoutError
           nil

--- a/lib/jekyll-gist/gist_tag.rb
+++ b/lib/jekyll-gist/gist_tag.rb
@@ -52,6 +52,7 @@ module Jekyll
       def gist_noscript_tag(gist_id, filename = nil)
         code = fetch_raw_code(gist_id, filename)
         if !code.nil?
+          code = code.force_encoding(@encoding)
           "<noscript><pre>#{CGI.escapeHTML(code)}</pre></noscript>"
         else
           Jekyll.logger.warn "Warning:", "The <noscript> tag for your gist #{gist_id} could not"
@@ -70,7 +71,7 @@ module Jekyll
             read_timeout: 3, open_timeout: 3) do |http|
             request = Net::HTTP::Get.new uri.to_s
             response = http.request(request)
-            response.body.force_encoding(@encoding)
+            response.body
           end
         rescue SocketError, Net::HTTPError, Net::OpenTimeout, Net::ReadTimeout, TimeoutError
           nil

--- a/lib/jekyll-gist/gist_tag.rb
+++ b/lib/jekyll-gist/gist_tag.rb
@@ -9,7 +9,7 @@ module Jekyll
     class GistTag < Liquid::Tag
 
       def render(context)
-        @encoding = context.registers[:site].config['encoding']
+        @encoding = context.registers[:site].config['encoding'] || 'utf-8'
         if tag_contents = determine_arguments(@markup.strip)
           gist_id, filename = tag_contents[0], tag_contents[1]
           if context.has_key?(gist_id)


### PR DESCRIPTION
This should fix #18 and #22 by ensuring gists are loaded into the same encoding as the site itself