### PR TITLE
Mention final install step in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Or install it yourself as:
 
     $ gem install jekyll-gist
 
+Finally, add the following to your site's `_config.yml`:
+
+```
+gems:
+  - jekyll-gist
+```
+
 ## Usage
 
 Use the tag as follows in your Jekyll pages, posts and collections:


### PR DESCRIPTION
Hi,

Requiring the gem itself within `_config.yml` is not obvious to all users. I believe it can't be bad adding this step to the README :memo: 