### PR TITLE
Allow noscript fallback to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ You may optionally specify a `filename` after the `gist_id`:
 
 This will produce the correct URL to show just the specified file in your post rather than the entire Gist.
 
+## Disabling `noscript` support
+
+By default, Jekyll Gist will make an HTTP call per Gist to retrieve the raw content of the Gist. This information is used to propagate `noscript` tags for search engines and browsers without Javascript support. If you'd like to disable this feature, for example, to speed up builds locally, simply add the following to your site's `_config.yml`:
+
+```yml
+gist:
+  noscript: false
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/jekyll/jekyll-gist/fork )

--- a/lib/jekyll-gist/gist_tag.rb
+++ b/lib/jekyll-gist/gist_tag.rb
@@ -10,6 +10,7 @@ module Jekyll
 
       def render(context)
         @encoding = context.registers[:site].config['encoding'] || 'utf-8'
+        @settings = context.registers[:site].config['gist']
         if tag_contents = determine_arguments(@markup.strip)
           gist_id, filename = tag_contents[0], tag_contents[1]
           if context.has_key?(gist_id)
@@ -50,6 +51,7 @@ module Jekyll
       end
 
       def gist_noscript_tag(gist_id, filename = nil)
+        return if @settings && @settings["noscript"] == false
         code = fetch_raw_code(gist_id, filename)
         if !code.nil?
           code = code.force_encoding(@encoding)

--- a/spec/gist_tag_spec.rb
+++ b/spec/gist_tag_spec.rb
@@ -18,7 +18,7 @@ describe(Jekyll::Gist::GistTag) do
       it "produces the correct script tag" do
         expect(output).to match(/<script src="https:\/\/gist.github.com\/#{gist}.js">\s<\/script>/)
       end
-      it "produces the correct noscript tag" do 
+      it "produces the correct noscript tag" do
         expect(output).to match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
       end
     end
@@ -30,7 +30,7 @@ describe(Jekyll::Gist::GistTag) do
       it "produces the correct script tag" do
         expect(output).to match(/<script src="https:\/\/gist.github.com\/#{gist}.js">\s<\/script>/)
       end
-      it "produces the correct noscript tag" do 
+      it "produces the correct noscript tag" do
         expect(output).to match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
       end
     end
@@ -42,7 +42,7 @@ describe(Jekyll::Gist::GistTag) do
       it "produces the correct script tag" do
         expect(output).to match(/<script src="https:\/\/gist.github.com\/#{gist}.js">\s<\/script>/)
       end
-      it "produces the correct noscript tag" do 
+      it "produces the correct noscript tag" do
         expect(output).to match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
       end
     end
@@ -56,7 +56,7 @@ describe(Jekyll::Gist::GistTag) do
       it "produces the correct script tag" do
         expect(output).to match(/<script src="https:\/\/gist.github.com\/#{gist}.js\?file=#{filename}">\s<\/script>/)
       end
-      it "produces the correct noscript tag" do 
+      it "produces the correct noscript tag" do
         expect(output).to match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
       end
     end
@@ -74,7 +74,7 @@ describe(Jekyll::Gist::GistTag) do
       it "produces the correct script tag" do
         expect(output).to match(/<script src="https:\/\/gist.github.com\/#{doc.data['gist_id']}.js">\s<\/script>/)
       end
-      it "produces the correct noscript tag" do 
+      it "produces the correct noscript tag" do
         expect(output).to match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
       end
     end
@@ -97,12 +97,12 @@ describe(Jekyll::Gist::GistTag) do
         expect(output).to match(/<script src="https:\/\/gist.github.com\/#{doc.data['gist_id']}.js\?file=#{doc.data['gist_filename']}">\s<\/script>/)
       end
 
-      it "produces the correct noscript tag" do 
+      it "produces the correct noscript tag" do
         expect(output).to match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
       end
     end
 
-    context "with valid gist id and invalid filename" do 
+    context "with valid gist id and invalid filename" do
       before { stub_request(:get, "https://gist.githubusercontent.com/#{gist_id}/raw/#{gist_filename}").to_return(status: 404) }
       let(:gist_id)     { "mattr-/24081a1d93d2898ecf0f" }
       let(:gist_filename) { "myfile.ext" }
@@ -112,14 +112,25 @@ describe(Jekyll::Gist::GistTag) do
         expect(output).to match(/<script src="https:\/\/gist.github.com\/#{gist_id}.js\?file=#{gist_filename}">\s<\/script>/)
       end
 
-      it "does not produce the noscript tag" do 
+      it "does not produce the noscript tag" do
         expect(output).to_not match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
       end
 
     end
 
-  end
+    context "with noscript disabled" do
+      let(:doc) { doc_with_content(content, { "gist" => { "noscript" => false } }) }
+      let(:output) do
+        doc.content = content
+        doc.output  = Jekyll::Renderer.new(doc.site, doc).run
+      end
 
+      it "does not produce the noscript tag" do
+        expect(output).to_not match(/<noscript>/)
+      end
+    end
+
+  end
 
   context "invalid gist" do
 

--- a/spec/gist_tag_spec.rb
+++ b/spec/gist_tag_spec.rb
@@ -124,6 +124,7 @@ describe(Jekyll::Gist::GistTag) do
         doc.content = content
         doc.output  = Jekyll::Renderer.new(doc.site, doc).run
       end
+      let(:gist) { "mattr-/24081a1d93d2898ecf0f" }
 
       it "does not produce the noscript tag" do
         expect(output).to_not match(/<noscript>/)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ RSpec.configure do |config|
   end
 
   def doc_with_content(content, opts = {})
-    my_site = site
+    my_site = site(opts)
     Jekyll::Document.new(source_dir('_test/doc.md'), {site: my_site, collection: collection(my_site)})
   end
 


### PR DESCRIPTION
Fixes https://github.com/jekyll/jekyll-gist/issues/17.
Fixes https://github.com/jekyll/jekyll-gist/issues/26.