### PR TITLE
Inherit Jekyll's rubocop config for consistency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,7 @@
+inherit_gem:
+  jekyll: .rubocop.yml
+
+Metrics/LineLength:
+  Exclude:
+    - spec/**/*
+    - jekyll-gist.gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 gemspec
 
 if ENV["GH_PAGES"]

--- a/jekyll-gist.gemspec
+++ b/jekyll-gist.gemspec
@@ -1,22 +1,23 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'jekyll-gist/version'
+require "jekyll-gist/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-gist"
   spec.version       = Jekyll::Gist::VERSION
   spec.authors       = ["Parker Moore"]
   spec.email         = ["parkrmoore@gmail.com"]
-  spec.summary       = %q{Liquid tag for displaying GitHub Gists in Jekyll sites.}
+  spec.summary       = "Liquid tag for displaying GitHub Gists in Jekyll sites."
   spec.homepage      = "https://github.com/jekyll/jekyll-gist"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = ">= 1.9.3"
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.executables   = spec.files.grep(%r!^bin/!) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r!^(test|spec|features)/!)
   spec.require_paths = ["lib"]
 
   spec.add_dependency "octokit", "~> 4.2"

--- a/lib/jekyll-gist/gist_tag.rb
+++ b/lib/jekyll-gist/gist_tag.rb
@@ -49,7 +49,7 @@ module Jekyll
 
       def context_contains_key?(context, key)
         if context.respond_to?(:has_key?)
-          context.key?(key)
+          context.has_key?(key)
         else
           context.key?(key)
         end

--- a/lib/jekyll-gist/gist_tag.rb
+++ b/lib/jekyll-gist/gist_tag.rb
@@ -1,6 +1,6 @@
-require 'cgi'
-require 'net/http'
-require 'octokit'
+require "cgi"
+require "net/http"
+require "octokit"
 
 Net::OpenTimeout = Class.new(RuntimeError) unless Net.const_defined?(:OpenTimeout)
 Net::ReadTimeout = Class.new(RuntimeError) unless Net.const_defined?(:ReadTimeout)
@@ -8,12 +8,12 @@ Net::ReadTimeout = Class.new(RuntimeError) unless Net.const_defined?(:ReadTimeou
 module Jekyll
   module Gist
     class GistTag < Liquid::Tag
-
       def render(context)
-        @encoding = context.registers[:site].config['encoding'] || 'utf-8'
-        @settings = context.registers[:site].config['gist']
+        @encoding = context.registers[:site].config["encoding"] || "utf-8"
+        @settings = context.registers[:site].config["gist"]
         if tag_contents = determine_arguments(@markup.strip)
-          gist_id, filename = tag_contents[0], tag_contents[1]
+          gist_id = tag_contents[0]
+          filename = tag_contents[1]
           if context_contains_key?(context, gist_id)
             gist_id = context[gist_id]
           end
@@ -24,7 +24,7 @@ module Jekyll
           script_tag = gist_script_tag(gist_id, filename)
           "#{noscript_tag}#{script_tag}"
         else
-          raise ArgumentError.new <<-eos
+          raise ArgumentError, <<-eos
   Syntax error in tag 'gist' while parsing the following markup:
 
     #{@markup}
@@ -41,7 +41,7 @@ module Jekyll
       private
 
       def determine_arguments(input)
-        matched = input.match(/\A([\S]+|.*(?=\/).+)\s?(\S*)\Z/)
+        matched = input.match(%r!\A([\S]+|.*(?=\/).+)\s?(\S*)\Z!)
         [matched[1].strip, matched[2].strip] if matched && matched.length >= 3
       end
 
@@ -49,7 +49,7 @@ module Jekyll
 
       def context_contains_key?(context, key)
         if context.respond_to?(:has_key?)
-          context.has_key?(key)
+          context.key?(key)
         else
           context.key?(key)
         end
@@ -87,8 +87,8 @@ module Jekyll
         url = "#{url}/#{filename}" unless filename.to_s.empty?
         uri = URI(url)
         Net::HTTP.start(uri.host, uri.port,
-          use_ssl: uri.scheme == 'https',
-          read_timeout: 3, open_timeout: 3) do |http|
+          :use_ssl => uri.scheme == "https",
+          :read_timeout => 3, :open_timeout => 3) do |http|
           request = Net::HTTP::Get.new uri.to_s
           response = http.request(request)
           response.body
@@ -103,15 +103,15 @@ module Jekyll
         gist = GistTag.client.gist gist_id
 
         file = if filename.to_s.empty?
-          # No file specified, return the value of the first key/value pair
-          gist.files.first[1]
-        else
-          # .files is a hash of :"filename.extension" => data pairs
-          # Rather than using to_sym on arbitrary user input,
-          # Find our file by calling to_s on the keys
-          match = gist.files.find { |name, data| name.to_s == filename }
-          match[1] if match
-        end
+                 # No file specified, return the value of the first key/value pair
+                 gist.files.first[1]
+               else
+                 # .files is a hash of :"filename.extension" => data pairs
+                 # Rather than using to_sym on arbitrary user input,
+                 # Find our file by calling to_s on the keys
+                 match = gist.files.find { |name, _data| name.to_s == filename }
+                 match[1] if match
+               end
 
         file[:content] if file
       end
@@ -123,4 +123,4 @@ module Jekyll
   end
 end
 
-Liquid::Template.register_tag('gist', Jekyll::Gist::GistTag)
+Liquid::Template.register_tag("gist", Jekyll::Gist::GistTag)

--- a/lib/jekyll-gist/version.rb
+++ b/lib/jekyll-gist/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module Gist
-    VERSION = "1.4.1"
+    VERSION = "1.4.1".freeze
   end
 end

--- a/spec/gist_tag_spec.rb
+++ b/spec/gist_tag_spec.rb
@@ -1,9 +1,9 @@
-require 'spec_helper'
+require "spec_helper"
 
 describe(Jekyll::Gist::GistTag) do
   let(:http_output) { "<test>true</test>" }
   let(:doc) { doc_with_content(content) }
-  let(:content)  { "{% gist #{gist} %}" }
+  let(:content) { "{% gist #{gist} %}" }
   let(:output) do
     doc.content = content
     doc.output  = Jekyll::Renderer.new(doc.site, doc).run
@@ -13,139 +13,138 @@ describe(Jekyll::Gist::GistTag) do
 
   context "valid gist" do
     context "with user prefix" do
-      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist}/raw").to_return(body: http_output) }
+      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist}/raw").to_return(:body => http_output) }
       let(:gist) { "mattr-/24081a1d93d2898ecf0f" }
 
       it "produces the correct script tag" do
-        expect(output).to match(/<script src="https:\/\/gist.github.com\/#{gist}.js">\s<\/script>/)
+        expect(output).to match(%r!<script src="https:\/\/gist.github.com\/#{gist}.js">\s<\/script>!)
       end
       it "produces the correct noscript tag" do
-        expect(output).to match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
+        expect(output).to match(%r!<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n!)
       end
     end
 
     context "without user prefix" do
-      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist}/raw").to_return(body: http_output) }
+      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist}/raw").to_return(:body => http_output) }
       let(:gist) { "28949e1d5ee2273f9fd3" }
 
       it "produces the correct script tag" do
-        expect(output).to match(/<script src="https:\/\/gist.github.com\/#{gist}.js">\s<\/script>/)
+        expect(output).to match(%r!<script src="https:\/\/gist.github.com\/#{gist}.js">\s<\/script>!)
       end
       it "produces the correct noscript tag" do
-        expect(output).to match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
+        expect(output).to match(%r!<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n!)
       end
     end
 
     context "classic Gist id style" do
-      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist}/raw").to_return(body: http_output) }
+      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist}/raw").to_return(:body => http_output) }
       let(:gist) { "1234321" }
 
       it "produces the correct script tag" do
-        expect(output).to match(/<script src="https:\/\/gist.github.com\/#{gist}.js">\s<\/script>/)
+        expect(output).to match(%r!<script src="https:\/\/gist.github.com\/#{gist}.js">\s<\/script>!)
       end
       it "produces the correct noscript tag" do
-        expect(output).to match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
+        expect(output).to match(%r!<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n!)
       end
     end
 
     context "with file specified" do
-      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist}/raw/#{filename}").to_return(body: http_output) }
+      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist}/raw/#{filename}").to_return(:body => http_output) }
       let(:gist)     { "mattr-/24081a1d93d2898ecf0f" }
       let(:filename) { "myfile.ext" }
       let(:content)  { "{% gist #{gist} #{filename} %}" }
 
       it "produces the correct script tag" do
-        expect(output).to match(/<script src="https:\/\/gist.github.com\/#{gist}.js\?file=#{filename}">\s<\/script>/)
+        expect(output).to match(%r!<script src="https:\/\/gist.github.com\/#{gist}.js\?file=#{filename}">\s<\/script>!)
       end
       it "produces the correct noscript tag" do
-        expect(output).to match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
+        expect(output).to match(%r!<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n!)
       end
     end
 
     context "with variable gist id" do
-      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist_id}/raw").to_return(body: http_output) }
+      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist_id}/raw").to_return(:body => http_output) }
       let(:gist_id)  { "1342013" }
       let(:gist)     { "page.gist_id" }
       let(:output) do
-        doc.data['gist_id'] = gist_id
+        doc.data["gist_id"] = gist_id
         doc.content = content
         doc.output  = Jekyll::Renderer.new(doc.site, doc).run
       end
 
       it "produces the correct script tag" do
-        expect(output).to match(/<script src="https:\/\/gist.github.com\/#{doc.data['gist_id']}.js">\s<\/script>/)
+        expect(output).to match(%r!<script src="https:\/\/gist.github.com\/#{doc.data['gist_id']}.js">\s<\/script>!)
       end
       it "produces the correct noscript tag" do
-        expect(output).to match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
+        expect(output).to match(%r!<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n!)
       end
     end
 
     context "with variable gist id and filename" do
-      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist_id}/raw/#{gist_filename}").to_return(body: http_output) }
+      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist_id}/raw/#{gist_filename}").to_return(:body => http_output) }
       let(:gist_id)       { "1342013" }
       let(:gist_filename) { "atom.xml" }
       let(:gist)          { "page.gist_id" }
       let(:filename)      { "page.gist_filename" }
       let(:content)       { "{% gist #{gist} #{filename} %}" }
       let(:output) do
-        doc.data['gist_id'] = "1342013"
-        doc.data['gist_filename'] = "atom.xml"
+        doc.data["gist_id"] = "1342013"
+        doc.data["gist_filename"] = "atom.xml"
         doc.content = content
         doc.output  = Jekyll::Renderer.new(doc.site, doc).run
       end
 
       it "produces the correct script tag" do
-        expect(output).to match(/<script src="https:\/\/gist.github.com\/#{doc.data['gist_id']}.js\?file=#{doc.data['gist_filename']}">\s<\/script>/)
+        expect(output).to match(%r!<script src="https:\/\/gist.github.com\/#{doc.data['gist_id']}.js\?file=#{doc.data['gist_filename']}">\s<\/script>!)
       end
 
       it "produces the correct noscript tag" do
-        expect(output).to match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
+        expect(output).to match(%r!<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n!)
       end
     end
 
     context "with valid gist id and invalid filename" do
-      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist_id}/raw/#{gist_filename}").to_return(status: 404) }
-      let(:gist_id)     { "mattr-/24081a1d93d2898ecf0f" }
+      before { stub_request(:get, "https://gist.githubusercontent.com/#{gist_id}/raw/#{gist_filename}").to_return(:status => 404) }
+      let(:gist_id) { "mattr-/24081a1d93d2898ecf0f" }
       let(:gist_filename) { "myfile.ext" }
-      let(:content)  { "{% gist #{gist_id} #{gist_filename} %}" }
+      let(:content) { "{% gist #{gist_id} #{gist_filename} %}" }
 
       it "produces the correct script tag" do
-        expect(output).to match(/<script src="https:\/\/gist.github.com\/#{gist_id}.js\?file=#{gist_filename}">\s<\/script>/)
+        expect(output).to match(%r!<script src="https:\/\/gist.github.com\/#{gist_id}.js\?file=#{gist_filename}">\s<\/script>!)
       end
 
       it "does not produce the noscript tag" do
-        expect(output).to_not match(/<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n/)
+        expect(output).to_not match(%r!<noscript><pre>&lt;test&gt;true&lt;\/test&gt;<\/pre><\/noscript>\n!)
       end
-
     end
 
     context "with token" do
       before { ENV["JEKYLL_GITHUB_TOKEN"] = "1234" }
-      before {
-        stub_request(:get, "https://api.github.com/gists/1342013").
-          to_return(:status => 200, :body => fixture("single-file"), :headers => {"Content-Type" => "application/json"})
-      }
+      before do
+        stub_request(:get, "https://api.github.com/gists/1342013")
+          .to_return(:status => 200, :body => fixture("single-file"), :headers => { "Content-Type" => "application/json" })
+      end
       let(:gist_id)  { "1342013" }
       let(:gist)     { "page.gist_id" }
       let(:output) do
-        doc.data['gist_id'] = gist_id
+        doc.data["gist_id"] = gist_id
         doc.content = content
         doc.output  = Jekyll::Renderer.new(doc.site, doc).run
       end
 
       it "produces the noscript tag" do
-        expect(output).to match(/<noscript><pre>contents of gist<\/pre><\/noscript>/)
+        expect(output).to match(%r!<noscript><pre>contents of gist<\/pre><\/noscript>!)
       end
 
       context "with a filename" do
-        before {
-          stub_request(:get, "https://api.github.com/gists/1342013").
-            to_return(:status => 200, :body => fixture("multiple-files"), :headers => {"Content-Type" => "application/json"})
-        }
-        let(:content)  { "{% gist 1342013 hello-world.rb %}" }
+        before do
+          stub_request(:get, "https://api.github.com/gists/1342013")
+            .to_return(:status => 200, :body => fixture("multiple-files"), :headers => { "Content-Type" => "application/json" })
+        end
+        let(:content) { "{% gist 1342013 hello-world.rb %}" }
 
         it "produces the noscript tag" do
-          expect(output).to match(/<noscript><pre>puts &#39;hello world&#39;<\/pre><\/noscript>/)
+          expect(output).to match(%r!<noscript><pre>puts &#39;hello world&#39;<\/pre><\/noscript>!)
         end
       end
     end
@@ -159,22 +158,18 @@ describe(Jekyll::Gist::GistTag) do
       let(:gist) { "mattr-/24081a1d93d2898ecf0f" }
 
       it "does not produce the noscript tag" do
-        expect(output).to_not match(/<noscript>/)
+        expect(output).to_not match(%r!<noscript>!)
       end
     end
-
   end
 
   context "invalid gist" do
-
     context "no gist id present" do
       let(:gist) { "" }
 
       it "raises an error" do
-        expect(->{ output }).to raise_error
+        expect(-> { output }).to raise_error
       end
     end
-
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,9 @@
-TEST_DIR = File.dirname(__FILE__)
+TEST_DIR = __dir__
 TMP_DIR  = File.expand_path("../tmp", TEST_DIR)
 
-require 'webmock/rspec'
-require 'cgi'
-require 'jekyll'
+require "webmock/rspec"
+require "cgi"
+require "jekyll"
 require File.expand_path("../lib/jekyll-gist.rb", TEST_DIR)
 
 Jekyll.logger.log_level = :error
@@ -11,39 +11,39 @@ Jekyll.logger.log_level = :error
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
-  config.order = 'random'
+  config.order = "random"
 
   def tmp_dir(*files)
     File.join(TMP_DIR, *files)
   end
 
   def source_dir(*files)
-    tmp_dir('source', *files)
+    tmp_dir("source", *files)
   end
 
   def dest_dir(*files)
-    tmp_dir('dest', *files)
+    tmp_dir("dest", *files)
   end
 
-  def doc_with_content(content, opts = {})
+  def doc_with_content(_content, opts = {})
     my_site = site(opts)
-    Jekyll::Document.new(source_dir('_test/doc.md'), {site: my_site, collection: collection(my_site)})
+    Jekyll::Document.new(source_dir("_test/doc.md"), { :site => my_site, :collection => collection(my_site) })
   end
 
-  def collection(site, label = 'test')
+  def collection(site, label = "test")
     Jekyll::Collection.new(site, label)
   end
 
   def site(opts = {})
     conf = Jekyll::Utils.deep_merge_hashes(Jekyll::Configuration::DEFAULTS, opts.merge({
       "source"      => source_dir,
-      "destination" => dest_dir
+      "destination" => dest_dir,
     }))
     Jekyll::Site.new(conf)
   end
 
   def fixture(name)
-    path = File.expand_path "./fixtures/#{name}.json", File.dirname(__FILE__)
+    path = File.expand_path "fixtures/#{name}.json", __dir__
     File.open(path).read
   end
 end


### PR DESCRIPTION
This PR is the result of adding `inherit_gem:\n jekyll: .rubocop.yml` to `.rubocop.yml` and running `rubocop -a` so that this project follows Jekyll core's coding styles for consistency like other core plugins. This way, as Jekyll's Ruby style changes, so too will this project's.