### PR TITLE
Re-introduce Ruby 2.3 support and test Jekyll 3.7+

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ inherit_gem:
   rubocop-jekyll: .rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.3
   Exclude:
     - vendor/**/*
     - spec/*.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.6
+  - &latest_ruby 2.6
   - 2.4
+  - 2.3
 
 script : script/cibuild
 
@@ -10,13 +11,15 @@ branches:
   only:
     - master
 env:
-  - JEKYLL_VERSION=3.7.4
-
+  matrix:
+  - JEKYLL_VERSION="~> 3.8"
 matrix:
   include:
     - # GitHub Pages
       rvm: 2.5.3
-      env: GH_PAGES=true
+      env: JEKYLL_VERSION="~> 3.7.4"
+    - rvm: *latest_ruby
+      env: JEKYLL_VERSION=">= 4.0.0.pre.alpha1"
 
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,4 @@
 source "https://rubygems.org"
 gemspec
 
-if ENV["GH_PAGES"]
-  gem "github-pages"
-elsif ENV["JEKYLL_VERSION"]
-  gem "jekyll", "~> #{ENV["JEKYLL_VERSION"]}"
-end
+gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]

--- a/jekyll-gist.gemspec
+++ b/jekyll-gist.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3.0"
 
-  spec.add_runtime_dependency "octokit", "~> 4.2"
   spec.add_runtime_dependency "jekyll", ">= 3.7", "< 5.0"
+  spec.add_runtime_dependency "octokit", "~> 4.2"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/jekyll-gist.gemspec
+++ b/jekyll-gist.gemspec
@@ -14,16 +14,16 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/jekyll/jekyll-gist"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.4.0"
-
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r!^bin/!) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r!^(test|spec|features)/!)
+  spec.test_files    = spec.files.grep(%r!^spec/!)
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "octokit", "~> 4.2"
+  spec.required_ruby_version = ">= 2.3.0"
+
+  spec.add_runtime_dependency "octokit", "~> 4.2"
+  spec.add_runtime_dependency "jekyll", ">= 3.7", "< 5.0"
+
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "jekyll", ">= 3.7", "< 5.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rubocop-jekyll", "~> 0.4"

--- a/lib/jekyll-gist/gist_tag.rb
+++ b/lib/jekyll-gist/gist_tag.rb
@@ -24,8 +24,10 @@ module Jekyll
         else
           raise ArgumentError, <<~ERROR
             Syntax error in tag 'gist' while parsing the following markup:
-             #{@markup}
-             Valid syntax:
+
+              #{@markup}
+
+            Valid syntax:
               {% gist user/1234567 %}
               {% gist user/1234567 foo.js %}
               {% gist 28949e1d5ee2273f9fd3 %}


### PR DESCRIPTION
Since we're not using Ruby 2.4 specific syntax, we can safely relax constraints on Ruby Version.

Other changes include:
  - **Add `jekyll` as a `runtime_dependency`**
  - *Remove superfluous gemspec specifications*
  - Test with Jekyll 4.0 pre-release
  - Correct whitespace alteration in `Jekyll::Gist::GistTag`