### PR TITLE
Use Liquid::Tag#raw to clarify error message

### DIFF
--- a/lib/jekyll-gist/gist_tag.rb
+++ b/lib/jekyll-gist/gist_tag.rb
@@ -25,7 +25,7 @@ module Jekyll
           raise ArgumentError, <<~ERROR
             Syntax error in tag 'gist' while parsing the following markup:
 
-              #{@markup}
+              '{% #{raw.strip} %}'
 
             Valid syntax:
               {% gist user/1234567 %}

--- a/spec/gist_tag_spec.rb
+++ b/spec/gist_tag_spec.rb
@@ -168,7 +168,7 @@ describe(Jekyll::Gist::GistTag) do
       let(:gist) { "" }
 
       it "raises an error" do
-        expect(-> { output }).to raise_error
+        expect(-> { output }).to raise_error(ArgumentError)
       end
     end
   end


### PR DESCRIPTION
This is to add clarity to the error message output when the tag is used without any arguments by using Liquid's builtin [`Liquid::Tag#raw`](https://github.com/Shopify/liquid/blob/f2f467bdbc248e7bf26b4f5e552cfbce6052f811/lib/liquid/tag.rb#L27-L29)

### Currently on `master`
```
Liquid Exception: Syntax error in tag 'gist' while parsing the following markup: Valid syntax:
{% gist user/1234567 %} {% gist user/1234567 foo.js %} {% gist 28949e1d5ee2273f9fd3 %} {% gist
28949e1d5ee2273f9fd3 best.md %} in source/_test/doc.md
```

### With the proposed change
```
Liquid Exception: Syntax error in tag 'gist' while parsing the following markup: '{% gist %}'
Valid syntax: {% gist user/1234567 %} {% gist user/1234567 foo.js %} {% gist 28949e1d5ee2273f9
fd3 %} {% gist 28949e1d5ee2273f9fd3 best.md %} in source/_test/doc.md
```